### PR TITLE
Feature/supervisory board

### DIFF
--- a/Association/association.tex
+++ b/Association/association.tex
@@ -49,7 +49,7 @@
 \begin{titlepage}
     \maketitle
     \begin{abstract}
-        This document describes the process in which the Wyvern community is governed. The roles, responsibilities, and rights of the administration team are formally introduced. In addition, the democratic voting process is described, the financial responsibilities of Wyvern members are discussed, and lastly, possible commissions are presented.
+        This document describes the process in which the Wyvern community is governed. The roles, responsibilities, and rights of the administration team are formally introduced. In addition, the democratic voting process is described, the financial responsibilities of Wyvern members are discussed, and lastly, committees are presented.
     \end{abstract}
 \end{titlepage}
 \pagenumbering{arabic}

--- a/Association/association.tex
+++ b/Association/association.tex
@@ -49,7 +49,7 @@
 \begin{titlepage}
     \maketitle
     \begin{abstract}
-        This document describes the process in which the Wyvern community is governed. The roles, responsibilities, and rights of the administration team are formally introduced. In addition, the democratic voting process is described, the financial responsibilities of Wyvern members are discussed, and lastly, committees are presented.
+        This document describes the Wyvern association. In particular, it describes the foundation of the Wyvern community and the process in which the Wyvern community is governed. The roles, responsibilities, and rights of the administration team and the supervisory board are formally introduced. In addition, the democratic voting process is described, the financial obligations of Wyvern members and the association as a whole are discussed, and lastly, Wyvern committees are presented.
     \end{abstract}
 \end{titlepage}
 \pagenumbering{arabic}

--- a/Association/section/community.tex
+++ b/Association/section/community.tex
@@ -20,6 +20,9 @@
 
     \item Wyvern's primary asset is a shared networked computer (the~'server').
 
+    %
+    % Administration Team
+    %
     \item Wyvern has an administration team comprised of Wyvern members. The administration team acts in behalf of and represents the Wyvern community.
 
     \item The administration team is elected by majority vote for the duration of six months (one 'term'). At the end of a term, the administration team is re-elected.
@@ -69,11 +72,43 @@
        \end{enumerate}
     \end{item}
 
+    %
+    % Supervisory Board
+    %
+    \item Wyvern has a supervisory board comprised of Wyvern members. The supervisory board oversees the administration team and committees the behalf of the Wyvern community.
+    
+    \item The supervisory board members are appointed, suspended, and discharged through a community meeting.
+    
+    \item The administration team consists of at least one member: the \emph{Chairman}.
+    
+    \begin{item}
+        The responsibilities and duties of the supervisory board are:
+        \begin{enumerate}
+            \item monitor the decisions of the administration team and committees, validating that each change represents and reflects the desires of the Wyvern Community;
+            \item monitor the responsibilities of the administration team and committees, validating that each responsibility is accounted for. For example, the meeting notes must be published in a timely manner and the security of the Wyvern server must be safeguarded;
+            \item validate and ratify the correctness of the Wyvern balance and the budgets of Wyvern committees during and after each Wyvern term, in conjunction with  the administration team;
+            \item ensure that the Wyvern Articles of Association are otherwise adhered to.
+        \end{enumerate}
+    \end{item}
+
+    \begin{item}
+        Members of the supervisory board must be provided with maximal insight into the administration team and committees.
+        \begin{enumerate}
+            \item The supervisory board may attend administration and committee meetings and must receive their respective meeting notes.
+            \item The supervisory board must be able to access all communication channels between administration team members and between committee members.
+        \end{enumerate}
+    \end{item}
+
+    %
+    % Committees
+    %
     \item At the discretion of the Wyvern community meeting, committees may be erected.
 
     \item Committees are comprised of Wyvern members are under the authority and oversight of the administration team.
 
     \item Unless decided otherwise, committee members are appointed, suspended, and discharged through a community meeting.
+    
+    \item Committee members are automatically discharged through Wyvern membership termination.
 
     \item Committees may convene and act independently of the Wyvern community.
 
@@ -82,8 +117,8 @@
     \begin{item}
             Commissions may raise, manage, and expend funds independently and autonomously subject to a budget.
             \begin{enumerate}
-                \item Committee budgets require ratification from the administration team before they are put into effect.
-                \item Committee budgets must be settled before committees members are discharged. The settlement requires ratification from the administration team.
+                \item Committee budgets require ratification from the administration team and the supervisory board before they are put into effect.
+                \item Committee budgets must be settled before committees members are discharged. The settlement requires ratification from the administration team and the supervisory board.
                 \item Post-settlement, any remaining credit is entrusted to the administration team as Wyvern funds.
             \end{enumerate}
     \end{item}

--- a/Association/section/community.tex
+++ b/Association/section/community.tex
@@ -86,7 +86,7 @@
         \begin{enumerate}
             \item monitor the decisions of the administration team and committees, validating that each change represents and reflects the desires of the Wyvern Community;
             \item monitor the responsibilities of the administration team and committees, validating that each responsibility is accounted for. For example, the meeting notes must be published in a timely manner and the security of the Wyvern server must be safeguarded;
-            \item validate and ratify the correctness of the Wyvern balance and the budgets of Wyvern committees during and after each Wyvern term, in conjunction with  the administration team;
+            \item validate and ratify the correctness of the Wyvern balance and the budgets of Wyvern committees during and after each Wyvern term, in conjunction with the administration team;
             \item ensure that the Wyvern Articles of Association are otherwise adhered to.
         \end{enumerate}
     \end{item}

--- a/Association/section/democracy.tex
+++ b/Association/section/democracy.tex
@@ -1,9 +1,9 @@
 \section{Democratic Process}
 \label{sec:democratic-process}
 \begin{enumerate}
-    \item Wyvern has community meetings, administration meetings, and commission meetings.
+    \item Wyvern has community meetings, administration meetings, and committee meetings.
     
-    \item Administration and commission meetings are managed internally by their respective body.
+    \item Administration and committee meetings are managed internally by their respective body.
 
     \item With exception of article~\ref{sec:democratic-process}.\ref{itm:meeting-exceptional}, community meetings are organized by the Director.
     


### PR DESCRIPTION
Suggestion: A Supervisory Board

Summary: To ensure that the desires of the Wyvern community are being adequately realized, we could erect a small supervisory board to monitor the Wyvern community, including its administration team and committees.

Currently, the administration team takes on both the executive and the supervisory role in the Wyvern community. The Director has two potentially conflicting responsibilities: representing the interests and desires of the Wyvern community (Articles of Association 1.10.a) and overseeing the administration team, (Articles of Association 1.10.b). Therefore, the Director should both be the executor and the evaluator of changes in the Wyvern community, and this responsibility lies solely with one member. If the administration team or the committees are not fully functional, such was the case last term (certain members did not have a user account on the server and applications were not installed), it is difficult to track this issue and resolve it.
To resolve this, I propose to create a small supervisory board which has the primary responsiblity of monitoring the Wyvern Administration Team and Committees. The goal is to separate the executive and supervisory roles. The responsibilities of the supervisory board are to:

   (a) monitor the decisions of the Administration Team and Commitees, validating that each change represents and reflects the desires of the Wyvern Community;
   (b) monitor the responsibilities of the Administration Team and Commitees, validating that each responsibility is accounted for. For example, the meeting notes must be published in a timely manner and the security of the Wyvern server must be safeguarded;
   (c) validate and ratify the correctness of the Wyvern balance and the budgets of Wyvern committees during and after each Wyvern term, in conjunction with  the adminstration team;
   (d) ensure that the Wyvern Articles of Association are otherwise adhered to.

The supervisory board primarily takes the role of auditor, passively observing the Wyvern community. The supervisory board does not gain executive power, although the board must be provided with maximal insight into the Administration Team and Committees. This includes access to the Administration Team and Committee meetings and their respective meeting notes, as well as access to their other communication channels.(edited)
