### PR TITLE
Let the admin team decide the contribution

### DIFF
--- a/Association/section/democracy.tex
+++ b/Association/section/democracy.tex
@@ -37,9 +37,10 @@
 
     \item With exception of articles~\ref{sec:democratic-process}.\ref{itm:vote-money} and~\ref{sec:democratic-process}.\ref{itm:vote-policy}, the Director decides whichever vote type is applicable before the vote is started.
 
-    \item \label{itm:vote-money} If a vote is related to Wyvern funds, it must be unanimous.
-
-    \item \label{itm:vote-policy} If a vote is related to the Wyvern's policy, guidelines, or rules, it must be unanimous.
+    \item \label{itm:vote-money} Unless decided otherwise, if a vote is related to Wyvern funds, it must be unanimous.
+    
+    \item \label{itm:vote-policy} Unless decided otherwise, if a vote is related to the Wyvern's policy, guidelines, or rules, it must be unanimous.
+    
 
     \begin{item}
         For a majority vote to succeed, the following conditions must be met:

--- a/Association/section/financial.tex
+++ b/Association/section/financial.tex
@@ -11,12 +11,10 @@
     \begin{item}
         All members must pay contribution.
         \begin{enumerate}
-            \item The contribution fee is equal to the server upkeep costs for one term divided by the number of Wyvern members.
-            \item The contribution fee is calculated at the beginning of a term and is fixed for the duration of that term.
+            \item The contribution fee is decided by the administration team. The minimum contribution is $C_m = \frac{S-F}{M}$ euros and the maximum contribution is $C_m = \frac{S}{M} + 5$ euros, where $C_m$ is the individual member contribution, $S$ is the costs for the upkeep of the server for the next term, and $F$ is the amount of Wyvern funds.
+            \item The contribution fee for the next term is calculated at the end of a term and is fixed for the duration of the next term.
         \end{enumerate}
     \end{item}
-
-    \item \label{itm:funds} Unless otherwise decided in a vote, all Wyvern funds are available for the upkeep of the server at the next term.
 
     \item With exception of article \ref{sec:financial}.\ref{itm:funds}, the Chief of Finance may only expend Wyvern funds with approval from the Wyvern community through a vote.
 

--- a/Association/section/financial.tex
+++ b/Association/section/financial.tex
@@ -11,7 +11,7 @@
     \begin{item}
         All members must pay contribution.
         \begin{enumerate}
-            \item The contribution fee is decided by the administration team. The minimum contribution is $C_m = \frac{S-F}{M}$ euros and the maximum contribution is $C_m = \frac{S}{M} + 5$ euros, where $C_m$ is the individual member contribution, $S$ is the costs for the upkeep of the server for the next term, and $F$ is the amount of Wyvern funds.
+            \item The contribution fee is decided by the administration team. The minimum contribution is $C_m = \frac{S-F}{M}$ euros and the maximum contribution is $C_m = \frac{S}{M} + 5$ euros, where $C_m$ is the individual member contribution, $S$ is the costs for the upkeep of the server for the next term, $F$ is the amount of Wyvern funds, and $M$ is the amount of Wyvern members in the next term.
             \item The contribution fee for the next term is calculated at the end of a term and is fixed for the duration of the next term.
         \end{enumerate}
     \end{item}


### PR DESCRIPTION
Suggestion: Let the Admin Team decide the contribution.

Currently, all Wyvern funds are fully expended towards the payment of the next term of the dedicated server. This resulted in a significant drop in contribution from last term to this term and that there are no Wyvern funds left.

To resolve this, I propose that the administration team decides at the end of each term what the contribution of the next term will be, with a minimum of (server costs - Wyvern funds)/(Wyvern members) and a maximum of (server costs)/(Wyvern members) + 5. The maximum contribution can then be set such that Wyvern loses or accumulates money to the desires of the Admin team.

The potential benefits include more flexibility in Wyvern assets (what else would we like to share? Perhaps shared board games?) as well as higher liquidity, allowing for the survival of Wyvern even after unexpected setbacks (such as the LAN budget settling with a negative amount).