### PR TITLE
Add voting deferral proposal

### DIFF
--- a/Association/section/democracy.tex
+++ b/Association/section/democracy.tex
@@ -19,7 +19,17 @@
 
     \item Before a vote is held, the Director must allow for members to abstain from voting. Abstaining is only possible by leaving the room in which the vote is held. If the meeting is held electronically, abstaining members must leave the call.
     
-    \item Wyvern members who are neither physically nor digitally present abstain on all votes by default.
+    \item Wyvern members who are neither physically nor digitally present and are not represented by another Wyvern member abstain on all votes by default.
+    
+    \begin{item}
+    	Wyvern members can defer their voting right to other members for the purpose of decision making.
+    	\begin{enumerate}
+    		\item Wyven members who will not attend the upcoming meeting can defer their voting rights to another member. This allows the receiving party to vote during the meeting as if the deferring party is present;
+    		\item The Director needs to be notified by the deferring party as to who will be the recieving party before the start of the meeting;
+    		\item Voting rights can only be deferred for the duration of one meeting;
+    		\item The receiving party may never have more than three votes during a meeting. A receiving party can only receive two votes from other members.
+    	\end{enumerate}
+    \end{item}
 
     \item Wyvern members who have a conflict of interest abstain by default. A conflict of interest is present if the respective Wyvern member is the subject of the vote.
 


### PR DESCRIPTION
Suggestion: Allow members to give the right to their vote to other members for the duration of one meeting.

Currently all members need to be present to have an unanimous vote. This pressures the members to be at a meeting and a meeting to be held only when all members can attend. This is undesirable as it increases the complexity.

We can and should not throw away user votes when people are not attending. I propose the option for members to give their vote to another member. These members can then for the duration of one pre-agreed-on meeting vote for the absent party. The present member gains full voting rights as-if he/she would be the absent party. The absent party is responsible for the choice of present party to represent him/her, votes made by the present party are final as-if absent party was present. To prevent vote-stacking one members should only ever have the right of three votes at any meeting (being their own, and that of one or two other Wyvern members). To prevent grief and increase transparity, the voting options (i.e. "Should we change x, or should we host y") should be made available to all members (for example through the discord) at least one day ahead of the meeting.

The potential benefit lies in more flexibility in the meetings, less bureaucracy stalling decision making and an increase in decision-making potential per-meeting.